### PR TITLE
[NUMBLE-11]) feat (mysql) : cloud MySQL DB 변경

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ repositories {
     mavenCentral()
 }
 
+jar{
+    enabled = false
+}
+
 dependencies {
     implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.springframework.boot:spring-boot-starter-web'
@@ -33,7 +37,7 @@ dependencies {
 
     implementation 'org.springdoc:springdoc-openapi-ui:1.6.12'
 
-    implementation 'com.h2database:h2'
+    implementation 'mysql:mysql-connector-java'
 
     implementation 'com.github.ulisesbocchio:jasypt-spring-boot-starter:3.0.4'
 

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -1,18 +1,17 @@
 spring:
   application:
-    name: numble
+    name: backend
   profiles:
     active: local
   datasource:
-    driver-class-name: org.h2.Driver
-    url: ENC(2p8Fem65AGKPMt3jefLYxI8+zc56BIX3cdB6tT3KYJrPlUbQaPKXVWvaCvFFJfkh)
-    username: sa
-    password:
-
+    driver-class-name: com.mysql.cj.jdbc.Driver
+    url: ENC(1KX2eCaflj6ajgwm6ldGhgwFIlU1023AkInhSrDpncoPJRMbf8a8Y6qr8rPWTWrU7CeGaV/9sXkuN+0416C42qy5lCZH7s4r371LMMrXpyk=)
+    username: ENC(k4WfV4exwYNosxz0AC0T7El92cK3GWa/)
+    password: ENC(h0Hy9BQqTkAHM2cJQeRV8NHsdYOvAG9ELvwbPlwG+Jo=)
   jpa:
     properties:
       hibernate:
-        dialect: org.hibernate.dialect.H2Dialect
+        dialect: org.hibernate.dialect.MySQL8Dialect
         show_sql: true
         format_sql: true
         use_sql_comments: true


### PR DESCRIPTION
### 완료 조건

naver cloud 내의 cloud db for mysql DB 를 프로젝트 내에 적용

### 주안점

개발서버 오픈을 위해서 커밋 내용 변경

현 naver cloud DB 는 비용이 많이 나감으로, 현재 프로젝트 서비스 오픈 전까지 내부 DB로 작업 요망
